### PR TITLE
fix: timing issue with tests

### DIFF
--- a/test/instrumentation/github-issue-1770.js
+++ b/test/instrumentation/github-issue-1770.js
@@ -1,7 +1,8 @@
 const agent = require('../..').start({
   serviceName: 'test',
   secretToken: 'test',
-  centralConfig: false
+  centralConfig: false,
+  metricsInterval:0
 })
 
 const tape = require('tape')


### PR DESCRIPTION
This PR fixes a timing issue with the test in `test/instrumentation/github-issue-1770.js` in certain versions of Node.js.  Specifically, the invocation of `mockClient`

```
    mockClient(3, cb)
```

expects three writes.  If a merticset is reported during the period the test runs in there will actually be four writes, which means the `mockClient` will start evaluating tests too early.  Test in Node 8.6 were failing because a metrics set was reported. 

This PR fixes the test by turning metric reporting off for this specific integration test.  